### PR TITLE
[ref #67] Fix a few memory leaks

### DIFF
--- a/src/components/tetris/reaktor-tetris.tsx
+++ b/src/components/tetris/reaktor-tetris.tsx
@@ -26,6 +26,10 @@ class _ReaktorTetris extends Component<
     this.game.start()
   }
 
+  componentWillUnmount() {
+    this.game.stop()
+  }
+
   render() {
     const { board } = this.state
     return board ? <Tetris board={board} /> : null

--- a/src/games/tetris/looped-reaktor-game.ts
+++ b/src/games/tetris/looped-reaktor-game.ts
@@ -1,22 +1,28 @@
-import { ReplaySubject } from "rxjs"
+import { Subject } from "rxjs"
 import { ReaktorGame } from "./reaktor-game"
 import { TetrisMatrix } from "./shape"
 
 export class LoopedReaktorGame {
   private reaktorGame = new ReaktorGame()
-  boardChange = new ReplaySubject<TetrisMatrix>()
+  boardChange = new Subject<TetrisMatrix>()
+  private isRunning = true
 
   async start() {
-    let subscripiton = this.reaktorGame.boardChange.subscribe(board =>
+    let subscription = this.reaktorGame.boardChange.subscribe(board =>
       this.boardChange.next(board),
     )
-    while (true) {
+    while (this.isRunning) {
       await this.reaktorGame.start()
-      subscripiton.unsubscribe()
+      subscription.unsubscribe()
+      this.reaktorGame.unsubscribe()
       this.reaktorGame = new ReaktorGame()
-      subscripiton = this.reaktorGame.boardChange.subscribe(board =>
+      subscription = this.reaktorGame.boardChange.subscribe(board =>
         this.boardChange.next(board),
       )
     }
+  }
+
+  stop() {
+    this.isRunning = false
   }
 }


### PR DESCRIPTION
- Stop the while (true) loop when ReaktorTetris unmounts
- Unsubscribe from all streams before disposing a ReactorGame instance
- Don't use ReplaySubject in LoopedReaktorGame as it's unnecessary

This closes #67.