### PR TITLE
[ref #72] Remove extensive logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,8 +41,8 @@ async function main() {
   const controllerNamespace = io.of("/controller")
 
   const state = new State(
-    new SocketIODisplays(displayNamespace, logger),
-    new SocketIOControllers(controllerNamespace, logger),
+    new SocketIODisplays(displayNamespace),
+    new SocketIOControllers(controllerNamespace),
     () => new Game({ columnCount: 10, rowCount: 16 }),
   )
   createSocketIOServer(

--- a/src/server/socketio-adapters.ts
+++ b/src/server/socketio-adapters.ts
@@ -1,6 +1,5 @@
 import { Namespace, Socket } from "socket.io"
 import { commands } from "../commands"
-import { Logger } from "../logger"
 import {
   Controller,
   Controllers,
@@ -13,7 +12,7 @@ import {
 export class SocketIODisplays implements Displays {
   private state: DisplayState | undefined
 
-  constructor(private namespace: Namespace, private logger: Logger) {}
+  constructor(private namespace: Namespace) {}
 
   add(): void {
     return // automatically handled by socketio
@@ -26,31 +25,20 @@ export class SocketIODisplays implements Displays {
   updateState(state: DisplayState): void {
     const currentState = this.getState()
     this.state = { ...currentState, ...state }
-    this.log({ event: "state" })
     this.namespace.emit("state", state)
   }
 
   sendAction(action: string): void {
-    this.log({
-      event: commands.ACTION,
-      command: action,
-    })
     this.namespace.emit(commands.ACTION, action)
   }
 
   getState(): DisplayState | undefined {
     return this.state
   }
-
-  private log(payload: object) {
-    this.logger.info(
-      JSON.stringify({ ...payload, client: "displays", direction: "send" }),
-    )
-  }
 }
 
 export class SocketIOControllers implements Controllers {
-  constructor(private namespace: Namespace, private logger: Logger) {}
+  constructor(private namespace: Namespace) {}
 
   add(): void {
     return // automatically handled by socketio
@@ -61,49 +49,22 @@ export class SocketIOControllers implements Controllers {
   }
 
   updateState(state: ControllerState): void {
-    this.log({ event: "state" })
     this.namespace.emit("state", state)
-  }
-
-  private log(payload: object) {
-    this.logger.info(
-      JSON.stringify({ ...payload, client: "controllers", direction: "send" }),
-    )
   }
 }
 
 export class SocketIODisplay implements Display {
-  constructor(private socket: Socket, private logger: Logger) {}
+  constructor(private socket: Socket) {}
 
   updateState(state: DisplayState): void {
-    this.log({
-      id: this.socket.id,
-      event: "state",
-    })
     this.socket.emit("state", state)
-  }
-
-  private log(payload: object) {
-    this.logger.info(
-      JSON.stringify({ ...payload, client: "display", direction: "send" }),
-    )
   }
 }
 
 export class SocketIOController implements Controller {
-  constructor(private socket: Socket, private logger: Logger) {}
+  constructor(private socket: Socket) {}
 
   updateState(state: ControllerState): void {
-    this.log({
-      id: this.socket.id,
-      event: "state",
-    })
     this.socket.emit("state", state)
-  }
-
-  private log(payload: object) {
-    this.logger.info(
-      JSON.stringify({ ...payload, client: "controller", direction: "send" }),
-    )
   }
 }

--- a/src/server/socketio.ts
+++ b/src/server/socketio.ts
@@ -10,7 +10,7 @@ export function createSocketIOServer(
   logger: Logger,
 ): void {
   namespaces.display.on("connect", displaySocket => {
-    const display = new SocketIODisplay(displaySocket, logger)
+    const display = new SocketIODisplay(displaySocket)
     log({ id: displaySocket.id, event: "connect", client: "display" })
     state.onDisplayConnect(display)
 
@@ -21,7 +21,7 @@ export function createSocketIOServer(
   })
 
   namespaces.controller.on("connect", controllerSocket => {
-    const controller = new SocketIOController(controllerSocket, logger)
+    const controller = new SocketIOController(controllerSocket)
     log({ id: controllerSocket.id, event: "connect", client: "controller" })
     state.onControllerConnect(controller)
 


### PR DESCRIPTION
Hopefully this will improve the socket throughput a bit so that controlling the tetris blocks feels a bit snappier. No idea if this works though.

This closes #72.