### PR TITLE
Force https if FORCE_HTTPS env var is set to true

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ GA_DEBUG_MODE=false
 
 # Bugsnag
 BUGSNAG_CLIENT_ID=<Bugsnag client ID>
+
+# Set to "true" to redirect all http requests to https
+FORCE_HTTPS=false

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import dotenv from "dotenv"
+dotenv.config()
 import { clientConfig } from "./client-config"
 
 export const config = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,4 +9,5 @@ export const config = {
     spreadsheetID: process.env.TRANSLATION_SPREADSHEET_ID,
     sheetName: process.env.TRANSLATION_SHEET_NAME,
   },
+  forceHttps: process.env.FORCE_HTTPS === "true",
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import dotenv from "dotenv"
 import express, { ErrorRequestHandler } from "express"
 import { createServer } from "http"
 import pino from "pino"
@@ -16,7 +15,6 @@ import {
   SocketIODisplays,
 } from "./server/socketio-adapters"
 import { State } from "./server/state"
-dotenv.config()
 
 async function main() {
   const logger = pino()

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ async function main() {
 
   const app = express()
   if (config.forceHttps) {
+    app.enable("trust proxy")
     app.use(httpsRedirectMiddleware)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { defaultTranslations } from "./i18n/default-translations"
 import { createLoadTranslationsFromSheets } from "./i18n/load-translations-from-sheets"
 import { createNextApp } from "./next"
 import { asyncMiddleware } from "./server/express-async-middleware"
+import { httpsRedirectMiddleware } from "./server/https-redirect-middleware"
 import { createSocketIOServer } from "./server/socketio"
 import {
   SocketIOControllers,
@@ -25,6 +26,10 @@ async function main() {
   )
 
   const app = express()
+  if (config.forceHttps) {
+    app.use(httpsRedirectMiddleware)
+  }
+
   app.get(
     "/api/translations",
     asyncMiddleware(async (_req, res) => {

--- a/src/server/https-redirect-middleware.ts
+++ b/src/server/https-redirect-middleware.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from "express"
+
+export function httpsRedirectMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (req.secure) {
+    next()
+  } else {
+    res.redirect(`https://${req.headers.host}${req.url}`)
+  }
+}


### PR DESCRIPTION
Adds redirect from `http://` to `https://`, which is enabled if the
environment variable `FORCE_HTTPS` is set to `true`. When enabled, `trust proxy` is also enabled so we get the actual proto from Heroku's `X-Forwarded-Proto`.

Additionally moves `dotenv.config()` to `config.ts` so it's executed before reading from `process.env`.

Closes #61 