### PR TITLE
Add tetris score gain effects

### DIFF
--- a/src/components/score-effects/index.ts
+++ b/src/components/score-effects/index.ts
@@ -1,0 +1,1 @@
+export * from "./score-effects"

--- a/src/components/score-effects/score-effects.story.tsx
+++ b/src/components/score-effects/score-effects.story.tsx
@@ -1,0 +1,69 @@
+import { storiesOf } from "@storybook/react"
+import React, { Fragment } from "react"
+import { ReaktorTetris } from "../tetris/reaktor-tetris"
+import { ScoreEffects } from "./score-effects"
+
+storiesOf("Score effects", module).add("Reaktor tetris", () => (
+  <Fragment>
+    <div className="tetris-wrapper">
+      <WithScore>
+        {({ score, onScoreIncreased }) => (
+          <Fragment>
+            <ScoreEffects score={score}>
+              <ReaktorTetris />
+            </ScoreEffects>
+            <div>
+              <button onClick={() => onScoreIncreased(10)}>Play effect</button>
+            </div>
+          </Fragment>
+        )}
+      </WithScore>
+    </div>
+    <style global={true} jsx>{`
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+      }
+
+      .tetris-wrapper {
+        width: 95%;
+        height: 95%;
+      }
+    `}</style>
+  </Fragment>
+))
+
+interface WithScoreState {
+  score: number
+}
+
+interface WithScoreRendererProps {
+  score: number
+  onScoreIncreased: (increment: number) => void
+}
+
+interface WithScoreProps {
+  children: React.SFC<WithScoreRendererProps>
+}
+
+class WithScore extends React.Component<WithScoreProps, WithScoreState> {
+  state = { score: 0 }
+
+  handleScoreIncreased = (increment: number) => {
+    this.setState(prevState => ({
+      score: prevState.score + increment,
+    }))
+  }
+
+  render() {
+    const { children: Renderer } = this.props
+    return (
+      <Renderer
+        score={this.state.score}
+        onScoreIncreased={this.handleScoreIncreased}
+      />
+    )
+  }
+}

--- a/src/components/score-effects/score-effects.tsx
+++ b/src/components/score-effects/score-effects.tsx
@@ -2,14 +2,8 @@ import React, { Fragment } from "react"
 import { colors } from "../../styles/colors"
 
 const screenShakeKeyframes = [
-  {
-    filter: "saturate(300%) blur(4px) contrast(80%) brightness(250%)",
-    transform: "scale(1.05)",
-  },
-  {
-    filter: "none",
-    transform: "none",
-  },
+  { transform: "scale(1.05)" },
+  { transform: "none" },
 ] as Keyframe[]
 
 const scoreGainKeyframes = [

--- a/src/components/score-effects/score-effects.tsx
+++ b/src/components/score-effects/score-effects.tsx
@@ -1,0 +1,97 @@
+import React, { Fragment } from "react"
+import { colors } from "../../styles/colors"
+
+const screenShakeKeyframes = [
+  {
+    filter: "saturate(300%) blur(4px) contrast(80%) brightness(250%)",
+    transform: "scale(1.05)",
+  },
+  {
+    filter: "none",
+    transform: "none",
+  },
+] as Keyframe[]
+
+const scoreGainKeyframes = [
+  {
+    opacity: "1",
+    transform: "translateY(0) scale(3)",
+  },
+  {
+    opacity: "0",
+    transform: "translateY(-80vh) scale(1)",
+  },
+] as Keyframe[]
+
+interface ScoreEffectsProps {
+  score: number
+}
+
+interface ScoreEffectsState {
+  scoreGained: number
+}
+
+export class ScoreEffects extends React.Component<
+  ScoreEffectsProps,
+  ScoreEffectsState
+> {
+  state = {
+    scoreGained: 0,
+  }
+
+  private rootRef = React.createRef<HTMLDivElement>()
+  private scoreRef = React.createRef<HTMLDivElement>()
+
+  componentDidUpdate(prevProps: ScoreEffectsProps) {
+    if (prevProps.score < this.props.score) {
+      // play effects only if score was gained
+      this.setState({
+        scoreGained: this.props.score - prevProps.score,
+      })
+      this.rootRef.current!.animate(screenShakeKeyframes, {
+        easing: "cubic-bezier(0.0, 0.0, 0.2, 1)",
+        duration: 820,
+      })
+      this.scoreRef.current!.animate(scoreGainKeyframes, {
+        easing: "cubic-bezier(0.0, 0.0, 0.2, 1)",
+        duration: 2000,
+      })
+    }
+  }
+
+  render() {
+    const { children } = this.props
+    const { scoreGained } = this.state
+
+    return (
+      <Fragment>
+        <div className="score-effects" ref={this.rootRef}>
+          <div className="score-effects__score" ref={this.scoreRef}>
+            +{scoreGained}
+          </div>
+          {children}
+        </div>
+        <style jsx>{`
+          .score-effects {
+            height: 100%;
+            transform-origin: bottom;
+            position: relative;
+          }
+          .score-effects__score {
+            position: absolute;
+            width: 100%;
+            bottom: 0;
+            color: ${colors.WHITE};
+            font-size: 4.5vmax;
+            pointer-events: none;
+            text-align: center;
+            opacity: 0;
+            transform-origin: initial;
+            text-shadow: 0 3px 6px rgba(0, 0, 0, 0.16),
+              0 3px 6px rgba(0, 0, 0, 0.23);
+          }
+        `}</style>
+      </Fragment>
+    )
+  }
+}

--- a/src/styles/z-indices.ts
+++ b/src/styles/z-indices.ts
@@ -1,4 +1,6 @@
 export const zIndices = {
-  FULLSCREEN_BAR: 2,
+  HUD: 20,
+  FULLSCREEN_BAR: 10,
+  GAME: 1,
   BACKGROUND: -10,
 }

--- a/src/views/display/display-game/display-game.tsx
+++ b/src/views/display/display-game/display-game.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, SFC } from "react"
+import { ScoreEffects } from "../../../components/score-effects"
 import { Tetris } from "../../../components/tetris"
 import {
   TranslateProps,
@@ -7,6 +8,7 @@ import {
 import { TetrisMatrix } from "../../../games/tetris/shape"
 import { formatSeconds } from "../../../helpers"
 import { colors } from "../../../styles/colors"
+import { zIndices } from "../../../styles/z-indices"
 import { HUDItem } from "./hud-item"
 
 interface DisplayGameProps extends TranslateProps {
@@ -35,7 +37,9 @@ export const _DisplayGame: SFC<DisplayGameProps> = ({
           />
         </div>
         <div className="display-game__tetris">
-          <Tetris board={board} />
+          <ScoreEffects score={score}>
+            <Tetris board={board} />
+          </ScoreEffects>
         </div>
       </div>
       <style jsx>{`
@@ -52,6 +56,7 @@ export const _DisplayGame: SFC<DisplayGameProps> = ({
           flex-direction: row;
           align-items: center;
           color: ${colors.WHITE};
+          z-index: ${zIndices.HUD};
           background: linear-gradient(
             to bottom,
             rgba(0, 0, 0, 1) 0%,
@@ -60,6 +65,7 @@ export const _DisplayGame: SFC<DisplayGameProps> = ({
         }
 
         .display-game__tetris {
+          z-index: ${zIndices.GAME};
           text-align: center;
           height: 100%;
         }


### PR DESCRIPTION
When gaining score, the screen now "shakes" (with nice CSS filters) and the gained score is flown on the screen from the bottom up. Z-indices were added because `filter` creates a new stacking context which, without the indices, raises the game element *above* the HUD.

Demo:
https://gfycat.com/entirewelltodoirishredandwhitesetter

I think that the one step delay between the block hitting the bottom and the score incrementing is due to how the "you can still move the block before it's locked down" behaviour is implemented. Would require more research.

Closes #55 