### PR TITLE
Fix duplicate commands after client reconnections

### DIFF
--- a/src/components/with-socket.tsx
+++ b/src/components/with-socket.tsx
@@ -46,10 +46,17 @@ export function withSocket<Props>(
     componentDidMount() {
       this.socket = createSocket()
       this.socket.on("connect", () => {
-        this.setupCommFromServer()
-        this.setupCommToServer()
         this.setState({ didSocketConnect: true })
       })
+
+      // Register event handlers outside the `connect` handler so that
+      // they aren't re-registered on reconnection! For example, if the user
+      // is connected and they lock their screen, the OS's power management
+      // systems will probably start throttling/deferring network requests,
+      // causing reconnections *without* causing an unmount.
+      // https://socket.io/docs/client-api/#Event-%E2%80%98connect%E2%80%99
+      this.setupCommFromServer()
+      this.setupCommToServer()
     }
 
     private setupCommFromServer() {


### PR DESCRIPTION
The socket's event handlers and rxjs subscriptions were registered inside the "connect" event handler. This means that they were re-registered every time the socket reconnected after a network hiccup. This caused the client to send duplicate commands to the server, so for example one "slide left" gesture sent as many "LEFT" commands as there were reconnections.

Fixed by moving the subscriptions outside the "connect" handler.

Closes #90 