### PR TITLE
Restrict jest worker count on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,4 @@ jobs:
 
       - run: yarn build
 
-      - run: yarn test
+      - run: yarn test --maxWorkers=2


### PR DESCRIPTION
We were getting failed test runs because of timeouts or memory errors. This was apparently caused by jest spawning 35 worker processes when in fact we only had 2 CPUs available.

When getting the amount of CPUs on CircleCI, jest gets 36 as the value. This is probably the actual amount of CPUs available to the docker engine, but it's not the amount available to *us*. To us, CircleCI
provides 2 CPUs.

This commit sets the jest option --maxWorkers=2 for CircleCI.