### PR TITLE
Fix fullscreen bar story

### DIFF
--- a/src/components/fullscreen-bar/fullscreen-bar.story.tsx
+++ b/src/components/fullscreen-bar/fullscreen-bar.story.tsx
@@ -1,12 +1,17 @@
 import { storiesOf } from "@storybook/react"
 import React, { Fragment } from "react"
+import { defaultTranslations } from "../../i18n/default-translations"
+import { createTranslate } from "../../i18n/translate"
 import { colors } from "../../styles/colors"
+import { TranslationContext } from "../contexts"
 import { FullscreenBar } from "./fullscreen-bar"
 
 storiesOf("Fullscreen bar", module).add("Default", () => (
   <Fragment>
     <div className="fullscreen-bar-wrapper">
-      <FullscreenBar />
+      <TranslationContext.Provider value={createTranslate(defaultTranslations)}>
+        <FullscreenBar />
+      </TranslationContext.Provider>
     </div>
     <style global={true} jsx>{`
       html,


### PR DESCRIPTION
Story was broken because the component uses `translate` but no translation context was used in the story.

Fixed by adding a translation context with the default translations.